### PR TITLE
Fix numpy include path for in-tree venv

### DIFF
--- a/python/meson.build
+++ b/python/meson.build
@@ -1,8 +1,9 @@
 py = import('python').find_installation()
 
+# Get numpy include path as relative path (works with in-tree venv)
 numpy_include_result = run_command(
     py,
-    ['-c', 'import numpy; print(numpy.get_include())'],
+    ['-c', 'import os; import numpy; print(os.path.relpath(numpy.get_include()))'],
     check: true
 )
 incdir_numpy = numpy_include_result.stdout().strip()


### PR DESCRIPTION
## Summary
Fix meson build error when using virtual environment inside source tree

## Changes
- Convert numpy include path from absolute to relative in `python/meson.build:6`

## Problem
Meson rejects absolute paths pointing into source tree:
```
ERROR: Tried to form an absolute path to a dir in the source tree.
```

Occurs when `.venv` located inside project directory.

## Solution
Use `os.path.relpath()` to convert numpy include path to relative (matches SciPy approach from scipy/scipy#18006)

## Test
- Built successfully with in-tree venv
- All 355 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>